### PR TITLE
feat: onnx input files

### DIFF
--- a/python/converter.py
+++ b/python/converter.py
@@ -5,6 +5,8 @@ import tensorflow as tf
 import numpy as np
 import tflite
 import msgpack
+import onnxmltools
+import os
 
 def get_shape(interpreter: tf.lite.Interpreter, tensor_idx):
   if tensor_idx == -1:
@@ -28,6 +30,14 @@ class Converter:
       self, model_path, scale_factor, k, num_cols, num_randoms, use_selectors, commit,
       expose_output
     ):
+    
+    if model_path[-6:] != "tflite":  # In the case of a non-tflite input model. 
+      if model_path[-4:] == "onnx":
+        output_path = os.getcwd() + "/"
+        cmd = "onnx2tf -i" + model_path + " -o " + output_path
+        os.system(cmd)
+      model_path = model_path[:-5] + "_float32.tflite"
+    
     self.model_path = model_path
     self.scale_factor = scale_factor
     self.k = k
@@ -42,6 +52,8 @@ class Converter:
       experimental_preserve_all_tensors=True
     )
     self.interpreter.allocate_tensors()
+
+    
 
     with open(self.model_path, 'rb') as f:
       buf = f.read()
@@ -521,6 +533,8 @@ def main():
   parser.add_argument('--end_layer', type=int, default=10000)
   parser.add_argument('--num_randoms', type=int, default=20001)
   args = parser.parse_args()
+
+  print(args.model)
 
   converter = Converter(
     args.model,


### PR DESCRIPTION
Conversion of input model from .onnx format into .tflite since the transpiler is based on .tflite. 

Requirements:
[onnx2tf ](https://github.com/PINTO0309/onnx2tf)

How I tested: 
- Downloaded a mnist model in .onnx format into a new example folder 
- Followed the same procedure mentioned in https://github.com/ddkang/zkml#converting-your-own-model-and-data 
- Code ran successfully and created the required .msgpack files